### PR TITLE
Added Devuan as a Debian alternative

### DIFF
--- a/invidious_update.sh
+++ b/invidious_update.sh
@@ -287,7 +287,13 @@ else
   echo -e "${RED}${ERROR} Error: Sorry, your OS is not supported.${NC}"
   exit 1;
 fi
-
+# Check if systemd is installed on Devuan
+if [[ $(lsb_release -si) == "Devuan" ]]; then
+  if ( ! $SYSTEM_CMD 2>/dev/null); then
+    echo -e "${RED}${ERROR} Error: Sorry, you need systemd to run this script.${NC}"
+    exit 1;
+  fi
+fi
 # Make sure that the script runs with root permissions
 chk_permissions() {
   if [[ "$EUID" != 0 ]]; then

--- a/invidious_update.sh
+++ b/invidious_update.sh
@@ -132,7 +132,7 @@ if lsb_release -si >/dev/null 2>&1; then
   DISTRO=$(lsb_release -si)
 fi
 case "$DISTRO" in
-  Debian*|Ubuntu*|LinuxMint*|PureOS*)
+  Debian*|Ubuntu*|LinuxMint*|PureOS*|Devuan*)
     # shellcheck disable=SC2140
     PKGCMD="apt-get -o Dpkg::Progress-Fancy="1" install -qq"
     LSB=lsb-release


### PR DESCRIPTION
- Devuan is a Debian systemd-free distribution and can be found at https://devuan.org
- it needs to be added as a Debian-based distribution to this script or
  otherwise it won't be detected correctly.
- still there is no systemctl command in Devuan, at least it exist optional. This change however doesn't reflect that.