### PR TITLE
Remove trailing slash from proxy_pass

### DIFF
--- a/invidious_update.sh
+++ b/invidious_update.sh
@@ -568,7 +568,7 @@ server {
   	# ssl_certificate_key /etc/nginx/certs/invidious.domain.tld/invidious.domain.tld.key;
 
   	location / {
-  		proxy_pass http://127.0.0.1:3000/;
+  		proxy_pass http://127.0.0.1:3000;
   		proxy_set_header X-Forwarded-For $remote_addr;
   		proxy_set_header Host $host;	# so Invidious knows domain
   		proxy_http_version 1.1;		# to keep alive


### PR DESCRIPTION
This implements https://github.com/iv-org/documentation/pull/269 to correct the `proxy_pass` directive.