### PR TITLE
Pass -Ddisable_quic to crystal build

### DIFF
--- a/invidious_update.sh
+++ b/invidious_update.sh
@@ -1148,7 +1148,7 @@ rebuild() {
   printf "\n-- Rebuilding ${REPO_DIR}\n"
   repoexit
   shards install --production
-  crystal build src/invidious.cr --release
+  crystal build src/invidious.cr --release -Ddisable_quic
   #sudo chown -R 1000:$USER_NAME $USER_DIR
   cd - || exit
   printf "\n"


### PR DESCRIPTION
Don't enable QUIC by default.
This change allows using invidious with postgres 14 and above